### PR TITLE
Add a module for the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ Big thank you to Bobloblah and The Happy Anarchist for laying the
 foundation of the ACKS compendium\! Both of them put in an enormous effort, all to
 save judges tons of work in getting their campaigns started.
 
+## Developer Instructions
+### The test suite
+
+There are tests that can be run inside of your Foundry instance through the `acks-tests` module.  To
+install the module locally, symlink that folder inside of your Foundry modules folder:
+```bash
+cd ~/.local/share/FoundryVTT/Data/modules
+ln -s ~/path/to/foundryvtt-acks-core/acks-tests acks-tests
+```
+Once that's done, reload Foundry and you will see "ACKS Test Suite" in your Add-on Modules list.
+You'll need to install the [Quench](https://ethaks.github.io/FVTT-Quench/index.html) module too,
+which can be done via the built-in module search functionality.
+
+To run the tests, log into a World which is using the ACKS System and go to Manage Modules to enable
+ACKS Test Suite.  It will prompt you to enable Quench.
+
+Now that it's installed and enabled, you will see a "🧪 Quench" button under your chat box. Click
+that and the tests will run.  You can also adjust your Quench defaults in the Configure Settings
+menu.
+
 ## License
 #### System
 

--- a/acks-tests/example-unit-tests.js
+++ b/acks-tests/example-unit-tests.js
@@ -1,0 +1,32 @@
+export function exampleUnitTests(context) {
+  const { describe, it, assert, expect, should } = context;
+
+  describe('Example Unit Tests', () => {
+    it("Passing Test", function () {
+      assert.ok(true);
+    });
+    it("Failing Test", function () {
+      assert.ok(false);
+    });
+    it("Passing Test using expect", function () {
+      expect(2).to.equal(2);
+    });
+    it("Failing Test using expect", function () {
+      expect(2).to.equal(undefined);
+    });
+    it("Passing Test using should", function () {
+      const foo = { bar: "baz" };
+      foo.should.have.property("bar", "baz");
+    });
+    it("Failing Test using should", function () {
+      const foo = { bar: "baz" };
+      foo.should.have.property("bar", "qux");
+    });
+    it("Passing Test using should helper", function () {
+      should.not.equal(1, 2);
+    });
+    it("Failing Test using should helper", function () {
+      should.equal(1, 2);
+    });
+  });
+}

--- a/acks-tests/module.json
+++ b/acks-tests/module.json
@@ -1,0 +1,33 @@
+{
+  "id": "acks-tests",
+  "name": "ACKS Test Suite",
+  "title": "ACKS Test Suite",
+  "description": "Automated tests for Adventurer Conqueror King System (ACKS) ruleset.",
+  "authors": [
+    {
+      "id": "Malex",
+      "discord": "malex_maleficarum",
+      "email": "AlexMMooney@gmail.com",
+      "url": "https://github.com/alexmooney"
+    }
+  ],
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "11",
+    "verified": "11"
+  },
+  "system": ["acks"],
+  "relationships": {
+    "requires": [{
+      "id": "quench",
+      "type": "module",
+      "manifest": "https://github.com/Ethaks/FVTT-Quench/releases/latest/download/module.json",
+      "compatibility": {
+        "verified": "0.9.2"
+      }
+    }]
+  },
+  "esmodules": [
+    "quench-init.js"
+  ]
+}

--- a/acks-tests/quench-init.js
+++ b/acks-tests/quench-init.js
@@ -1,0 +1,5 @@
+import { exampleUnitTests } from './example-unit-tests.js';
+
+Hooks.once('quenchReady', (quench) => {
+  quench.registerBatch('acks.examples', exampleUnitTests, { displayName: 'Example Unit Tests' });
+});


### PR DESCRIPTION
Create a module for the tests, so that developers can install it but users won't see it.

After enabling the module (instructions added in README) you'll get a button near the chat:
![image](https://github.com/AutarchLLC/foundryvtt-acks-core/assets/8269566/3601784b-a924-4803-9de0-8e5dba15f1e8)

When you push it, it runs the tests:
![image](https://github.com/AutarchLLC/foundryvtt-acks-core/assets/8269566/a092426a-0ffd-4fa6-998f-fe05dcd56ff1)

