### PR TITLE
Fixed MEL / MIS buttons on player's character sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .history/
 .vscode/settings.json
+.idea

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -48,7 +48,7 @@ export class AcksActorSheet extends ActorSheet {
     if (data) {
       let dataItem = JSON.parse( data);
       let actorId = dataItem.uuid.split('.')[1]
-      if ( dataItem.uuid.includes("Actor") && !dataItem.uuid.includes("Item") && actorId && actorId != this.actor.id) {  
+      if ( dataItem.uuid.includes("Actor") && !dataItem.uuid.includes("Item") && actorId && actorId != this.actor.id) {
         this.actor.addHenchman( actorId);
         return;
       }
@@ -200,11 +200,11 @@ export class AcksActorSheet extends ActorSheet {
       let save = element.parentElement.parentElement.dataset.save;
       actorObject.rollSave(save, { event: ev });
     });
-    
+
     html.find(".item .item-rollable .item-image").click(async (ev) => {
       const li = $(ev.currentTarget).parents(".item");
       const item = this.actor.items.get(li.data("itemId"));
-      
+
       let skip = false
       let skipKey = game.settings.get("acks", "skip-dialog-key");
       if (ev && ev[skipKey]) {
@@ -226,13 +226,13 @@ export class AcksActorSheet extends ActorSheet {
     html.find(".favorite-rollable").click(async (ev) => {
       const li = $(ev.currentTarget);
       const item = this.actor.items.get(li.data("itemId"));
-      
+
       let skip = false
       let skipKey = game.settings.get("acks", "skip-dialog-key");
       if (ev && ev[skipKey]) {
         skip = true;
       }
-  
+
       if (item.type == "weapon") {
         if (this.actor.type === "monster") {
           item.update({ 'system.counter.value': item.system.counter.value - 1 });
@@ -261,10 +261,10 @@ export class AcksActorSheet extends ActorSheet {
 
       let skip = false
       let skipKey = game.settings.get("acks", "skip-dialog-key");
-      if (options.event && options.event[skipKey]) {
+      if (ev[skipKey]) {
         skip = true;
       }
-  
+
       actorObject.targetAttack(rollData, attack, {
         type: attack,
         skipDialog: skip,


### PR DESCRIPTION
Fixed error so player can now press MEL or MIS buttons on his character sheet to roll attack
![image](https://github.com/user-attachments/assets/2a83d9f2-1d62-465f-a46a-d1a21739b7f9)
