### PR TITLE
Small v13 fixes

### DIFF
--- a/src/acks.css
+++ b/src/acks.css
@@ -1637,3 +1637,8 @@
   font-weight: bold;
   color: darkgreen;
 }
+
+/* V13 fixes */
+.combat-tracker .combatant-controls {
+  flex-wrap: wrap;
+}

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -69,8 +69,8 @@ export const ACKS = {
   scores: {
     str: "ACKS.scores.str.long",
     int: "ACKS.scores.int.long",
-    dex: "ACKS.scores.dex.long",
     wis: "ACKS.scores.wis.long",
+    dex: "ACKS.scores.dex.long",
     con: "ACKS.scores.con.long",
     cha: "ACKS.scores.cha.long",
   },

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -11,47 +11,30 @@
                   <input name="system.hp.max" type="text" value="{{system.hp.max}}" data-dtype="Number" placeholder="0" />
               </div>
           </li>
-          <li class="attribute hit-dice">
-              <h4 class="attribute-name box-title" title="{{localize 'ACKS.HitDice'}}">
-                  <a>{{ localize "ACKS.HitDiceShort" }}</a>
+          <li class="attribute">
+              <h4 class="attribute-name box-title hit-dice" title="{{localize 'ACKS.HitDice'}}">
+                  <a><i class="acks-roll-small fa-solid fa-dice-d20"></i>{{ localize "ACKS.HitDiceShort" }}</a>
               </h4>
               <div class="attribute-value">
                   <input name="system.hp.hd" type="text" value="{{system.hp.hd}}" data-dtype="String" />
               </div>
           </li>
           <li class="attribute">
-              {{#if config.ascendingAC}}
               <h4 class="attribute-name box-title" title="{{ localize 'ACKS.ArmorClass' }}">
                   {{ localize "ACKS.AscArmorClassShort" }}</h4>
               <div class="attribute-value">
                   <input name="system.aac.value" type="text" value="{{system.aac.value}}" data-dtype="Number"
                       placeholder="10" data-dtype="Number" />
               </div>
-              {{else}}
-              <h4 class="attribute-name box-title" title="{{ localize 'ACKS.ArmorClass' }}">
-                  {{ localize "ACKS.ArmorClassShort" }}</h4>
-              <div class="attribute-value">
-                  <input name="system.ac.value" type="text" value="{{system.ac.value}}" data-dtype="Number"
-                      placeholder="9" data-dtype="Number" />
-              </div>
-              {{/if}}
           </li>
           <li class="attribute attack">
-              {{#if config.ascendingAC}}
-              <h4 class="attribute-name box-title" title="{{localize 'ACKS.AB'}}"><a>{{ localize "ACKS.ABShort" }}</a>
+              <h4 class="attribute-name box-title" title="{{localize 'ACKS.AB'}}">
+                  <a><i class="acks-roll-small fa-solid fa-dice-d20"></i>{{ localize "ACKS.ABShort" }}</a>
               </h4>
               <div class="attribute-value">
                   <input name="system.thac0.throw" type="text" value="{{system.thac0.throw}}" placeholder=""
                       data-dtype="Number" />
               </div>
-              {{else}}
-              <h4 class="attribute-name box-title" title="{{localize 'ACKS.Thac0'}}"><a>{{ localize "ACKS.Thac0" }}</a>
-              </h4>
-              <div class="attribute-value">
-                  <input name="system.thac0.value" type="text" value="{{system.thac0.value}}" placeholder="0"
-                      data-dtype="Number" />
-              </div>
-              {{/if}}
           </li>
           {{#if system.retainer.enabled}}
           <li class="attribute">
@@ -64,7 +47,7 @@
               </div>
           </li>
           {{/if}}
-          
+
           <li class="attribute">
               <h4 class="attribute-name box-title" title="{{localize 'ACKS.movement.base'}}">
                   {{ localize "ACKS.movement.short" }}
@@ -74,7 +57,7 @@
                       data-dtype="Number" />
               </div>
           </li>
-          
+
           <li class="attribute flexrow" >
             <h4 class="attribute-name box-title" title="({{localize 'ACKS.bonuses.initiativebonus'}}) {{localize 'ACKS.exploration.ld.long'}}">
               {{ localize "ACKS.bonuses.initiativebonus" }}


### PR DESCRIPTION
Fixed issue with combat tracker buttons in Foundry v13.
![image](https://github.com/user-attachments/assets/b7cec743-b7da-4153-9149-2736e3bf28b4)
Now:
![image](https://github.com/user-attachments/assets/f9394dd3-9f1f-459a-98b5-e727239dcd8c)
___
Fixed issue where if click text field to change HD of a monster, you get the Hit Dice roll dialogue instead; added Dice icons to HD and Throw sections of monster sheet to indicate you can click on them to roll;
![image](https://github.com/user-attachments/assets/8f9ebf6e-382f-4b17-b647-69e7eb9ea290)
___
Fixed attributes order in character creation dialogue to align with character sheet