### PR TITLE
Item Sheet v2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,10 +9,13 @@ srcdata
 7.5
 acks-tests
 docs
+images
 old_packs
 package
+
 src/assets
 src/packs
 
 **/*.md
 **/*.html
+**/*.hbs

--- a/src/acks.css
+++ b/src/acks.css
@@ -1642,3 +1642,155 @@
 .combat-tracker .combatant-controls {
   flex-wrap: wrap;
 }
+
+/** item sheet v2 **/
+.application.sheet.acks.item-v2 {
+  min-width: 570px;
+  min-height: 400px;
+}
+
+.acks.item-v2 .window-content input:not([type="checkbox"]) {
+  background: revert-layer;
+  border: revert-layer;
+  border-radius: revert-layer;
+  border-bottom: revert-layer;
+}
+.acks.item-v2 .window-content input:not([type="checkbox"]):hover:not(:disabled),
+.acks.item-v2 .window-content input:not([type="checkbox"]):focus:not(:disabled) {
+  box-shadow: revert-layer;
+  background: revert-layer;
+}
+
+.sheet.acks.item-v2 .window-content {
+  padding: 0.5rem;
+  gap: 0.5rem;
+}
+
+.sheet.acks.item-v2 .sheet-header {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.sheet.acks.item-v2 .sheet-header .profile-img {
+  width: 84px;
+  height: 84px;
+  min-width: 84px;
+  min-height: 84px;
+  cursor: var(--cursor-pointer);
+}
+
+.sheet.acks.item-v2 .sheet-header .middle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.sheet.acks.item-v2 .sheet-header .middle input[type="text"] {
+  font-size: var(--font-size-28);
+  line-height: var(--font-size-28);
+}
+
+.sheet.acks.item-v2 .sheet-header .flexrow {
+  gap: 0.5rem;
+}
+
+.sheet.acks.item-v2 .description .content {
+  gap: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+}
+
+.sheet.acks.item-v2 .description .stats {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  flex: 0 0 84px;
+  font-size: var(--font-size-13);
+}
+
+.sheet.acks.item-v2 .description .stats .form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.sheet.acks.item-v2 .description .stats .form-group label {
+  height: 20px;
+  line-height: 20px;
+}
+
+.sheet.acks.item-v2 .description .stats .form-group .form-fields {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.sheet.acks.item-v2 .description .stats select,
+.sheet.acks.item-v2 .description .stats input[type="text"] {
+  height: 1.5rem;
+  line-height: 1.5rem;
+  padding: 0 0.2rem;
+}
+
+.sheet.acks.item-v2 .description .item-description {
+  display: flex;
+  flex: 1;
+}
+
+.sheet.acks.item-v2 .description .item-description prose-mirror {
+  flex: 1;
+}
+
+.sheet.acks.item-v2 .tab[data-tab].active {
+  display: flex;
+  flex: 1;
+  overflow: hidden auto;
+}
+
+.sheet.acks.item-v2 .tab[data-tab]:not(.active) {
+  display: none;
+}
+
+.sheet.acks.item-v2 .active-effects .effects-list-content {
+  gap: 0.5rem;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.sheet.acks.item-v2 .active-effects ol.effect-list {
+  margin: 0;
+  padding: 0;
+  gap: 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.sheet.acks.item-v2 .active-effects ol.effect-list li {
+  margin: 0;
+  min-height: 2rem;
+  line-height: 1;
+}
+
+.sheet.acks.item-v2 .active-effects .effect-name {
+  flex: 2;
+  padding: 0 0.5rem;
+  gap: 0.25rem;
+}
+
+.sheet.acks.item-v2 .active-effects .effect-controls {
+  display: flex;
+  justify-content: space-evenly;
+  flex: 0 0 110px;
+}
+
+.sheet.acks.item-v2 .active-effects .effect-header {
+  background-color: var(--table-header-bg-color);
+  border-radius: 4px;
+}
+
+.sheet.acks.item-v2 a.button:hover,
+.sheet.acks.item-v2 button:hover {
+  background: var(--acks-purple);
+}

--- a/src/acks.js
+++ b/src/acks.js
@@ -18,6 +18,7 @@ import { AcksUtility } from "./module/utility.js";
 import { AcksPolyglot } from "./module/apps/polyglot-support.js";
 import { AcksTableManager } from "./module/apps/table-manager.js";
 import { AcksCommands } from "./module/apps/acks-commands.js";
+import AcksItemSheetV2 from "./module/item/item-sheet-v2.mjs";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -68,8 +69,14 @@ Hooks.once("init", async function () {
   });
   Items.unregisterSheet("core", ItemSheet);
   Items.registerSheet("acks", AcksItemSheet, {
-    makeDefault: true,
+    makeDefault: !AcksUtility.isV13(),
   });
+  if (AcksUtility.isV13()) {
+    Items.registerSheet("acks", AcksItemSheetV2, {
+      types: ["item"],
+      makeDefault: true,
+    });
+  }
 
   await preloadHandlebarsTemplates();
 
@@ -80,7 +87,7 @@ Hooks.once("init", async function () {
   CONFIG.ActiveEffect.legacyTransferral = false;
 
   Hooks.on("getSceneControlButtons", (controls) => {
-    const V13 = game.release.generation >= 13;
+    const V13 = AcksUtility.isV13();
     const targetControl = V13 ? controls?.tokens : controls.find((control) => control.name === "token");
     if (!targetControl) {
       return;

--- a/src/module/acks-token-hud.js
+++ b/src/module/acks-token-hud.js
@@ -61,7 +61,7 @@ export class AcksTokenHud {
 
   /* -------------------------------------------- */
   static async addTokenHudExtensions(app, html, tokenId) {
-    const $html = game.release.generation < 13 ? html : $(html);
+    const $html = AcksUtility.isV13() ? $(html) : html;
     const controlIconCombat = $html.find(".control-icon[data-action=combat]");
     if (controlIconCombat.length > 0) {
       AcksTokenHud.addExtensionHud(app, $html, tokenId);

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -538,7 +538,7 @@ export class AcksCombat {
       console.log("Color settings not found", e);
     }
 
-    const V13 = game.release.generation >= 13;
+    const V13 = AcksUtility.isV13();
     // in Application v2 html is NOT jQuery by default
     const $html = V13 ? $(html) : html;
     $html.find(".initiative").each((_, span) => {

--- a/src/module/effect/acks-effect-util.mjs
+++ b/src/module/effect/acks-effect-util.mjs
@@ -1,0 +1,69 @@
+export default class AcksEffectUtil {
+  /**
+   * Creates new ActiveEffect document and shows its sheet
+   * @param {string} effectType
+   * @param {AcksItem|ClientDocument} owner
+   * @return {Promise<void|*>}
+   */
+  static async addEffect(effectType, owner) {
+    // Get registered ActiveEffect Document Class (in case we are going to have custom one).
+    const ActiveEffectClass = getDocumentClass("ActiveEffect");
+
+    const effect = await ActiveEffectClass.implementation.create(
+      {
+        name: game.i18n.format("DOCUMENT.New", { type: game.i18n.localize("DOCUMENT.ActiveEffect") }),
+        transfer: true,
+        img: "icons/svg/aura.svg",
+        origin: owner.uuid,
+        "duration.rounds": effectType === "temporary" ? 1 : undefined,
+        disabled: effectType === "inactive",
+        changes: [{}],
+      },
+      { parent: owner },
+    );
+
+    return effect.sheet.render(true);
+  }
+
+  /**
+   * Toggles Active effect on a document
+   * @param {string} effectId
+   * @param {AcksItem|ClientDocument} owner
+   * @return {Promise<void>}
+   */
+  static async toggleEffect(effectId, owner) {
+    const effect = owner.effects.get(effectId);
+
+    if (effect) {
+      return effect.update({ disabled: !effect.disabled });
+    }
+  }
+
+  /**
+   * Edits Active effect on a document
+   * @param {string} effectId
+   * @param {AcksItem|ClientDocument} owner
+   * @return {Promise<void>}
+   */
+  static async editEffect(effectId, owner) {
+    const effect = owner.effects.get(effectId);
+
+    if (effect) {
+      return effect.sheet.render(true);
+    }
+  }
+
+  /**
+   * Deletes Active effect from a document
+   * @param {string} effectId
+   * @param {AcksItem|ClientDocument} owner
+   * @return {Promise<void>}
+   */
+  static async deleteEffect(effectId, owner) {
+    const effect = owner.effects.get(effectId);
+
+    if (effect) {
+      return effect.delete();
+    }
+  }
+}

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -1,4 +1,5 @@
 import { AcksDice } from "../dice.js";
+import { AcksUtility } from "../utility.js";
 
 /**
  * Override and extend the basic :class:`Item` implementation
@@ -33,7 +34,7 @@ export class AcksItem extends Item {
   }
 
   static chatListeners(html) {
-    const $html = game.release.generation < 13 ? html : $(html);
+    const $html = AcksUtility.isV13() ? $(html) : html;
     $html.on("click", ".card-buttons button", this._onChatCardAction.bind(this));
     $html.on("click", ".item-name", this._onChatCardToggleContent.bind(this));
   }

--- a/src/module/item/item-sheet-v2.mjs
+++ b/src/module/item/item-sheet-v2.mjs
@@ -1,0 +1,219 @@
+import { AcksUtility } from "../utility.js";
+import AcksEffectUtil from "../effect/acks-effect-util.mjs";
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+const { ItemSheetV2 } = foundry.applications.sheets;
+const TextEditorRef = foundry.applications?.ux?.TextEditor?.implementation ?? TextEditor;
+
+export default class AcksItemSheetV2 extends HandlebarsApplicationMixin(ItemSheetV2) {
+  constructor(...args) {
+    super(...args);
+  }
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["acks", "item-v2"],
+    position: {
+      // initial size of the window
+      width: 570,
+      height: 400,
+    },
+    window: {
+      resizable: true,
+    },
+    form: {
+      submitOnChange: true,
+      submitOnClose: true,
+    },
+    actions: {
+      // button actions, defined in template as data-action
+      createEffect: AcksItemSheetV2.#addEffect,
+      toggleEffect: AcksItemSheetV2.#toggleEffect,
+      editEffect: AcksItemSheetV2.#editEffect,
+      deleteEffect: AcksItemSheetV2.#deleteEffect,
+    },
+  };
+
+  /** @override */
+  static TABS = {
+    primary: {
+      tabs: [
+        { id: "description", label: "ACKS.category.description" },
+        { id: "effects", label: "ACKS.category.effects" },
+      ],
+      initial: "description",
+    },
+  };
+
+  /** @override */
+  tabGroups = {
+    primary: "description",
+  };
+
+  /** @override */
+  static PARTS = {
+    header: {
+      template: "systems/acks/templates/items/v2/item/header.hbs",
+    },
+    tabs: {
+      template: "templates/generic/tab-navigation.hbs",
+    },
+    description: {
+      template: "systems/acks/templates/items/v2/item/description.hbs",
+      scrollable: [""],
+    },
+    effects: {
+      template: "systems/acks/templates/items/v2/item/effects.hbs",
+      templates: ["systems/acks/templates/items/v2/common/item-active-effects.hbs"],
+      scrollable: [""],
+    },
+  };
+
+  get item() {
+    return this.document;
+  }
+
+  /**
+   * Prepare data for rendering the Item sheet
+   * The prepared data object contains both the actor data and additional sheet options
+   * @param {ApplicationRenderOptions} options https://foundryvtt.com/api/interfaces/foundry.applications.types.ApplicationRenderOptions.html
+   * @return {Promise<ApplicationRenderContext>} https://foundryvtt.com/api/interfaces/foundry.applications.types.ApplicationRenderContext.html
+   */
+  async _prepareContext(options) {
+    const context = {
+      ...(await super._prepareContext(options)),
+      item: this.item,
+      config: CONFIG.ACKS,
+      system: this.item.system,
+      isGM: game.user.isGM,
+    };
+
+    const enrichmentOptions = {
+      secrets: this.item.isOwner,
+      relativeTo: this.item,
+    };
+
+    context.enriched = {
+      description: await TextEditorRef.enrichHTML(this.item.system.description, enrichmentOptions),
+    };
+
+    return context;
+  }
+
+  /**
+   * Prepare context that is specific to only a single rendered part.
+   *
+   * It is recommended to augment or mutate the shared context so that downstream methods like _onRender have
+   * visibility into the data that was used for rendering. It is acceptable to return a different context object
+   * rather than mutating the shared context at the expense of this transparency.
+   *
+   * @param {string} partId                         The part being rendered
+   * @param {ApplicationRenderContext} context      Shared context provided by _prepareContext
+   * @param {HandlebarsRenderOptions} options       Options which configure application rendering behavior
+   * @returns {Promise<ApplicationRenderContext>}   Context data for a specific part
+   * @protected
+   */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+
+    switch (partId) {
+      case "description":
+        context.tab = context.tabs[partId];
+        break;
+      case "effects":
+        context.tab = context.tabs[partId];
+        context = await this._prepareEffectsContext(context);
+        break;
+      default:
+    }
+    return context;
+  }
+
+  /**
+   *
+   * @param {ApplicationRenderContext} context
+   * @return {Promise<ApplicationRenderContext>}
+   * @private
+   */
+  async _prepareEffectsContext(context) {
+    context.effects = await AcksUtility.prepareActiveEffectCategories(this.item.effects);
+
+    return context;
+  }
+
+  /**
+   * Handle adding new active effect.
+   * @this {AcksItemSheetV2}
+   * @param {Event} event
+   * @param {HTMLElement} target - add effect button
+   */
+  static async #addEffect(event, target) {
+    const effectType = target.dataset.effectType;
+    await AcksEffectUtil.addEffect(effectType, this.item);
+  }
+
+  /**
+   * Handle toggling of an active event.
+   * @this {AcksItemSheetV2}
+   * @param {Event} event
+   * @param {HTMLElement} target
+   * @return {Promise<void>}
+   */
+  static async #toggleEffect(event, target) {
+    const effectId = target.dataset.effectId;
+    await AcksEffectUtil.toggleEffect(effectId, this.item);
+  }
+
+  /**
+   * Handle editing of an active event.
+   * @this {AcksItemSheetV2}
+   * @param {Event} event
+   * @param {HTMLElement} target
+   * @return {Promise<void>}
+   */
+  static async #editEffect(event, target) {
+    const effectId = target.dataset.effectId;
+    await AcksEffectUtil.editEffect(effectId, this.item);
+  }
+
+  /**
+   * Handle deleting of an active event.
+   * @this {AcksItemSheetV2}
+   * @param {Event} event
+   * @param {HTMLElement} target
+   * @return {Promise<void>}
+   */
+  static async #deleteEffect(event, target) {
+    const effectId = target.dataset.effectId;
+    await AcksEffectUtil.deleteEffect(effectId, this.item);
+  }
+
+  /**
+   * Activate event listeners using the prepared sheet HTML
+   * @param html {HTML}   The prepared HTML object ready to be rendered into the DOM
+   */
+  activateListeners(html) {
+    /*html.find('input[data-action="add-tag"]').keypress((ev) => {
+      if (ev.which == 13) {
+        let value = $(ev.currentTarget).val();
+        let values = value.split(",");
+        this.object.pushTag(values);
+      }
+    });*/
+
+    /*html.find(".tag-delete").click((ev) => {
+      let value = ev.currentTarget.parentElement.dataset.tag;
+      this.object.popTag(value);
+    });*/
+
+    /*html.find("a.melee-toggle").click(() => {
+      this.object.update({ "system.melee": !this.object.system.melee });
+    });*/
+
+    /*html.find("a.missile-toggle").click(() => {
+      this.object.update({ "system.missile": !this.object.system.missile });
+    });*/
+
+    super.activateListeners(html);
+  }
+}

--- a/src/module/utility.js
+++ b/src/module/utility.js
@@ -2,6 +2,14 @@ import { AcksMortalWoundsDialog } from "./dialog/mortal-wounds.js";
 import { AcksTamperingDialog } from "./dialog/tampering-mortality.js";
 
 export class AcksUtility {
+  /**
+   * Checks for Foundry version
+   * @return {boolean} true if version is 13 or more
+   */
+  static isV13() {
+    return game.release.generation >= 13;
+  }
+
   /* -------------------------------------------- */
   static updateWeightsLanguages() {
     for (let a of game.actors) {
@@ -46,7 +54,7 @@ export class AcksUtility {
       let cr = new AcksTamperingDialog();
       cr.init();
     });
-    const $html = game.release.generation < 13 ? html : $(html);
+    const $html = AcksUtility.isV13() ? $(html) : html;
     $html.find(".header-actions").after(buttonTampering);
     $html.find(".header-actions").after(button);
   }
@@ -147,6 +155,7 @@ export class AcksUtility {
 
     // Iterate over active effects, classifying them into categories
     for (let e of effects) {
+      e.updateDuration();
       if (e.disabled) categories.inactive.effects.push(e);
       else if (e.isTemporary) categories.temporary.effects.push(e);
       else categories.passive.effects.push(e);

--- a/src/templates/items/v2/common/item-active-effects.hbs
+++ b/src/templates/items/v2/common/item-active-effects.hbs
@@ -1,0 +1,42 @@
+<div class="effects-list-content">
+  {{#each effects as |section|}}
+    <div class="effect-header flexrow">
+      <div class="effect-name">{{localize section.label}}</div>
+      <div class="effect-source">{{localize "ACKS.Effect.Source"}}</div>
+      <div class="effect-duration">{{localize "EFFECT.TABS.duration"}}</div>
+      <div class="effect-controls flexrow">
+        <button type="button" data-action="createEffect" data-tooltip
+                aria-label="{{localize 'DOCUMENT.Create' type='Effect'}}" data-effect-type="{{section.type}}">
+          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}
+        </button>
+      </div>
+    </div>
+
+    <ol class="effect-list">
+      {{#each section.effects as |effect|}}
+        <li class="effect flexrow">
+          <div class="effect-name flexrow">
+            <img class="effect-image" src="{{effect.img}}"/>
+            <div>{{effect.name}}</div>
+          </div>
+          <div class="effect-source">{{effect.sourceName}}</div>
+          <div class="effect-duration">{{effect.duration.label}}</div>
+          <div class="effect-controls">
+            <a class="effect-control button" data-action="toggleEffect" data-effect-id="{{effect.id}}"
+               title="{{localize 'BOILERPLATE.Effect.Toggle'}}">
+              <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+            </a>
+            <a class="effect-control button" data-action="editEffect" data-effect-id="{{effect.id}}"
+               title="{{localize 'DOCUMENT.Update' type="Effect"}}">
+              <i class="fas fa-edit"></i>
+            </a>
+            <a class="effect-control button" data-action="deleteEffect" data-effect-id="{{effect.id}}"
+               title="{{localize 'DOCUMENT.Delete' type="Effect"}}">
+              <i class="fas fa-trash"></i>
+            </a>
+          </div>
+        </li>
+      {{/each}}
+    </ol>
+  {{/each}}
+</div>

--- a/src/templates/items/v2/item/description.hbs
+++ b/src/templates/items/v2/item/description.hbs
@@ -1,0 +1,39 @@
+<section class="tab {{tab.cssClass}} description" data-group="primary" data-tab="description">
+  <div class="content">
+    <div class="stats">
+      <div class="form-group">
+        <label>{{localize 'ACKS.items.subtype'}}</label>
+        <div class="form-fields">
+          <select name="system.subtype" value="{{system.subtype}}" data-dtype="String">
+            {{selectOptions config.item_subtypes selected=system.subtype localize=true}}
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ACKS.items.quantity'}}</label>
+        <div class="form-fields">
+          <input type="text" name="system.quantity.value" value="{{system.quantity.value}}"
+                 data-dtype="Number"/>/<input type="text" name="system.quantity.max"
+                                              value="{{system.quantity.max}}" data-dtype="Number"/>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>{{localize 'ACKS.items.Cost'}}</label>
+        <div class="form-fields">
+          <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number"/>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>{{localize 'ACKS.items.Weight'}}</label>
+        <div class="form-fields">
+          <input type="text" name="system.weight6" value="{{system.weight6}}" data-dtype="Number"/>
+        </div>
+      </div>
+    </div>
+    <div class="item-description">
+      <prose-mirror name="system.description" value="{{ system.description }}"
+                    document-uuid="{{ item.uuid }}" compact toggled>{{{ enriched.description }}}</prose-mirror>
+    </div>
+  </div>
+</section>

--- a/src/templates/items/v2/item/effects.hbs
+++ b/src/templates/items/v2/item/effects.hbs
@@ -1,0 +1,3 @@
+<section class="tab {{tab.cssClass}} active-effects" data-group="primary" data-tab="effects">
+  {{> "systems/acks/templates/items/v2/common/item-active-effects.hbs"}}
+</section>

--- a/src/templates/items/v2/item/header.hbs
+++ b/src/templates/items/v2/item/header.hbs
@@ -1,0 +1,8 @@
+<section class="sheet-header">
+  <div class="left">
+    <img class="profile-img" src="{{item.img}}" alt="{{item.name}}" data-action="editImage" data-edit="img"/>
+  </div>
+  <div class="middle">
+    <input name="name" type="text" value="{{item.name}}" placeholder="Name"/>
+  </div>
+</section>


### PR DESCRIPTION
Item Sheet v2 - using [ApplicationV2](https://foundryvtt.com/api/classes/foundry.applications.api.ApplicationV2.html)
Only for Foundry v13+. 
For item of type "item" (and clothing) for now.
![image](https://github.com/user-attachments/assets/e3ca776a-ce1d-4821-9dad-26f51e2438a9)

Uses mostly default Foundry v13 styles. (I'm not a designer unfortunately). Supports Foundry's Dark and Light themes.
![image](https://github.com/user-attachments/assets/cfdaaaf8-9296-4575-a668-8aa323128277)
![image](https://github.com/user-attachments/assets/d9abc0b3-df22-4029-85e1-53a94958d87c)

No new features, just a facelift for now :) Foundry v12 is not affected. 
Old sheet can be enabled back via Configure Sheet setting:
![image](https://github.com/user-attachments/assets/3adf4644-2446-474b-8a7b-6b7748e96721)
![image](https://github.com/user-attachments/assets/329a6692-cd5d-4067-a489-af7d4e2e4733)

