### PR TITLE
Use raw document system in config context

### DIFF
--- a/src/module/apps/actor-tweaks-config.mjs
+++ b/src/module/apps/actor-tweaks-config.mjs
@@ -39,7 +39,7 @@ export default class ActorTweaksConfig extends HandlebarsApplicationMixin(Docume
     const context = await super._prepareContext(options);
 
     context.docFields = this.document.system.schema.fields;
-    context.system = this.document.system;
+    context.system = this.document._source.system;
     context.isGM = game.user.isGM;
 
     context.isCharacter = this.document.type === "character";


### PR DESCRIPTION
Change ActorTweaksConfig to read system data from the document's raw _source object instead of the potentially proxied document.system. This ensures the config UI receives the original stored system data (avoiding any runtime modifications) when preparing the Handlebars context. Closes #164