### PR TITLE
Remove fixed height from actor-v2 sheet content

### DIFF
--- a/src/acks.css
+++ b/src/acks.css
@@ -1899,7 +1899,6 @@
 
 .sheet.acks.actor-v2 .content {
   align-items: flex-start;
-  height: 100%;
 }
 
 .sheet.acks.actor-v2 .flex-unset,


### PR DESCRIPTION
Remove the `height: 100%` rule from `.sheet.acks.actor-v2 .content` in src/acks.css so the sheet can size naturally. This prevents forced full-height behavior that could cause layout or overflow issues with variable content.

Closes #184 