### PR TITLE
Localize simple sheet labels

### DIFF
--- a/src/templates/actors/v2/partials/attribute-score.hbs
+++ b/src/templates/actors/v2/partials/attribute-score.hbs
@@ -15,7 +15,7 @@
     <input name="system.scores.{{abbr}}.value" type="text" id="{{@root.partId}}-score-{{abbr}}"
            value="{{lookup (lookup (lookup system "scores") abbr) "value"}}" class="attribute-value__value"
            placeholder="0" data-dtype="Number"/>
-    <input type="text" value="{{mod (lookup (lookup (lookup system "scores") abbr) "mod")}}" data-tooltip="Modifier"
+    <input type="text" value="{{mod (lookup (lookup (lookup system "scores") abbr) "mod")}}" data-tooltip="{{localize "ACKS.Modifier"}}"
            class="attribute-value__mod" data-dtype="Number" disabled/>
   </div>
 </div>

--- a/src/templates/items/v2/item/header.hbs
+++ b/src/templates/items/v2/item/header.hbs
@@ -5,7 +5,7 @@
   </div>
 
   <div class="sheet-header__middle">
-    <input name="name" type="text" value="{{item.name}}" placeholder="Name"/>
+    <input name="name" type="text" value="{{item.name}}" placeholder="{{localize "ACKS.name"}}"/>
   </div>
 
   {{#if isPhysical}}


### PR DESCRIPTION
## Summary

Replaces two hardcoded UI strings with existing localization keys:

- Item Sheet name placeholder: `ACKS.name`
- Attribute modifier tooltip: `ACKS.Modifier`

## Scope

Changed only two Handlebars templates:

- `src/templates/items/v2/item/header.hbs`
- `src/templates/actors/v2/partials/attribute-score.hbs`

No behavior, data model, packs, migrations, combat, initiative, surprise, manifests, or lockfiles were changed.

## Validation

- `git diff --check`
- `npm.cmd run format:check`
- `npm.cmd run build`
- Manual Foundry VTT test:
  - Created/opened an Item
  - Confirmed empty item name field still shows `Name`
  - Opened Character Sheet
  - Confirmed attribute modifier tooltip still shows `Modifier`
  - Confirmed editing score still works
  - Confirmed rolling attribute still works

## Notes

Foundry showed an existing package warning about `manifestPlusVersion` in the system manifest. This PR does not change `system.json` and is unrelated to that warning.